### PR TITLE
Fix a typo in Sytle.md#typenames

### DIFF
--- a/style.md
+++ b/style.md
@@ -583,7 +583,7 @@ package com.example.deep_space
 
 ## Type names
 
-Class names are written in PascalCase and are typically nouns or noun phrases. For example, `Character` or `ImmutableList`. Interface names may also be nouns or noun phrases (for example, `List`), but my sometimes be adjectives or adjective phrases instead (for example `Readable`).
+Class names are written in PascalCase and are typically nouns or noun phrases. For example, `Character` or `ImmutableList`. Interface names may also be nouns or noun phrases (for example, `List`), but may sometimes be adjectives or adjective phrases instead (for example `Readable`).
 
 Test classes are named starting with the name of the class they are testing, and ending with `Test`. For example, `HashTest` or `HashIntegrationTest`.
 


### PR DESCRIPTION
In section Type Names, it looks like there's a typo in `but my sometimes`. It should be `but may sometimes`?