### PR TITLE
Typo fix in interop.md

### DIFF
--- a/interop.md
+++ b/interop.md
@@ -252,7 +252,7 @@ class KotlinClass {
 public final class JavaClass {
     public static void main(String... args) {
         System.out.println(KotlinClass.INTEGER_ONE);
-        System.out.println(KotlinClass.BIG_INTEGER_ONE;
+        System.out.println(KotlinClass.BIG_INTEGER_ONE);
     }
 }
 ```


### PR DESCRIPTION
Added missing round bracket for companion constants example.