### PR TITLE
Properties: Fix val with setter to var with setter

### DIFF
--- a/style.md
+++ b/style.md
@@ -309,10 +309,10 @@ private val defaultCharset: Charset? =
         EncodingRegistry.getInstance().getDefaultCharsetForPropertiesFiles(file)
 ```
 
-Properties declaring a `get` and/or `set` function should place each on their only line with a normal indent (+4). Format them using the same rules as functions.
+Mutable properties declaring a `get` and/or `set` function should place each on their only line with a normal indent (+4). Format them using the same rules as functions.
 
 ```kotlin
-val directory: File? = null
+var directory: File? = null
     set(value) {
         // …
     }

--- a/style.md
+++ b/style.md
@@ -309,7 +309,7 @@ private val defaultCharset: Charset? =
         EncodingRegistry.getInstance().getDefaultCharsetForPropertiesFiles(file)
 ```
 
-Mutable properties declaring a `get` and/or `set` function should place each on their only line with a normal indent (+4). Format them using the same rules as functions.
+Properties declaring a `get` and/or `set` function should place each on their only line with a normal indent (+4). Format them using the same rules as functions.
 
 ```kotlin
 var directory: File? = null


### PR DESCRIPTION
An example was incorrectly showing `val` with a setter.
This commit fixes it to `var`, and makes it more clear by stating it applies to mutable properties.