### PR TITLE
Fix HTTPS Mixed content

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -3,7 +3,7 @@
 
     <div class="mdl-cell mdl-cell--2-col mdl-cell--hide-phone mdl-cell--hide-tablet"></div>
 
-    <form class="header-content mdl-cell mdl-cell--8-col" action="http://www.google.com/search">
+    <form class="header-content mdl-cell mdl-cell--8-col" action="https://www.google.com/search">
 
         <!-- Expandable Textfield -->
           <div class="mdl-textfield mdl-js-textfield mdl-textfield--expandable textfield-demo">


### PR DESCRIPTION
Browsers will display a warning that it's not a secure connection before fixing `_includes/header.html`.
![image](https://user-images.githubusercontent.com/3166782/34067756-a67d315c-e269-11e7-9ebf-7d63024e56a4.png)
