### PR TITLE
Update property initializer wrap to +4

### DIFF
--- a/style.md
+++ b/style.md
@@ -302,14 +302,14 @@ Expression functions should not wrap to two lines. If an expression function gro
 
 ### Properties
 
-When a property initializer does not fit on a single line, break after the equals sign (`=`) and use a continuation indent.
+When a property initializer does not fit on a single line, break after the equals sign (`=`) and use a single indent (+4).
 
 ```kotlin
 private val defaultCharset: Charset? =
-        EncodingRegistry.getInstance().getDefaultCharsetForPropertiesFiles(file)
+    EncodingRegistry.getInstance().getDefaultCharsetForPropertiesFiles(file)
 ```
 
-Properties declaring a `get` and/or `set` function should place each on their own line with a normal indent (+4). Format them using the same rules as functions.
+Properties declaring a `get` and/or `set` function should place each on their own line with a single indent (+4). Format them using the same rules as functions.
 
 ```kotlin
 var directory: File? = null


### PR DESCRIPTION
Fixes a conflict with https://kotlinlang.org/docs/reference/coding-conventions.html#property-formatting which currently states:

> For properties with an initializer, if the initializer is long, add a line break after the equals sign and indent the initializer by four spaces