### PR TITLE
Change the way to define the main method for Java

### DIFF
--- a/interop.md
+++ b/interop.md
@@ -237,11 +237,9 @@ _Correct: `@JvmStatic` annotation_
 
 
 ```kotlin
-class KotlinClass {
-    companion object {
-        @JvmStatic fun doWork() {
+object KotlinClass {
+    @JvmStatic fun doWork(args: Array<String>) {
             /* … */
-        }
     }
 }
 ```


### PR DESCRIPTION
To define the `main` method of Java from Kotlin, if we define the Kotlin class as `object` is not needed to wrap the method inside the `companion object`. 
In my opinion, this approach is easier to understand if we want to define Java's `main` static method.

But if the the intention of the section is to show how to define any (not the main one) method as static for Java, maybe the `main` method is not the best example.

Also, in this case the method parameters aren't well defined as `doWork()` has no parameters.